### PR TITLE
fix: Better Dynamic Class Names Derived From Props Solution

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -2,7 +2,7 @@ import { ButtonHTMLAttributes } from "react";
 import { colors } from "../../types";
 import { sizes } from "../../types/size/sizes";
 import {
-  ClassNameTransformFn,
+  ClassNameTransformMap,
   createClassNameFromProps,
 } from "../../utilities";
 
@@ -20,14 +20,12 @@ export type ButtonProps = {
   loading?: boolean;
 } & ButtonHTMLAttributes<HTMLButtonElement>;
 
-const buttonClassNameMapping = new Map<keyof ButtonProps, ClassNameTransformFn>(
-  [
-    ["color", (color: string) => `is-${color.toLowerCase()}`],
-    ["light", () => "is-light"],
-    ["size", (size: string) => `is-${size}`],
-    ["loading", () => `is-loading`],
-  ]
-);
+const buttonClassNameMapping: ClassNameTransformMap<ButtonProps> = new Map([
+  ["color", (color: string) => `is-${color.toLowerCase()}`],
+  ["light", () => "is-light"],
+  ["size", (size: string) => `is-${size}`],
+  ["loading", () => `is-loading`],
+]);
 
 export const Button = ({
   color,

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -1,6 +1,10 @@
 import { ButtonHTMLAttributes } from "react";
 import { colors } from "../../types";
 import { sizes } from "../../types/size/sizes";
+import {
+  ClassNameTransformFn,
+  createClassNameFromProps,
+} from "../../utilities";
 
 export const ButtonColors = [...colors, "text", "ghost"] as const;
 
@@ -16,6 +20,15 @@ export type ButtonProps = {
   loading?: boolean;
 } & ButtonHTMLAttributes<HTMLButtonElement>;
 
+const buttonClassNameMapping = new Map<keyof ButtonProps, ClassNameTransformFn>(
+  [
+    ["color", (color: string) => `is-${color.toLowerCase()}`],
+    ["light", () => "is-light"],
+    ["size", (size: string) => `is-${size}`],
+    ["loading", () => `is-loading`],
+  ]
+);
+
 export const Button = ({
   color,
   light,
@@ -23,25 +36,21 @@ export const Button = ({
   loading,
   ...props
 }: ButtonProps): JSX.Element => {
-  const classes: string[] = ["button"];
+  const classNameProps: Partial<ButtonProps> = {
+    color,
+    light,
+    size,
+    loading,
+  };
 
-  if (color) {
-    classes.push(`is-${color.toLowerCase()}`);
-  }
-  if (light) {
-    classes.push(`is-light`);
-  }
-  if (size) {
-    classes.push(`is-${size}`);
-  }
-  if (loading) {
-    classes.push(`is-loading`);
-  }
-
-  const className = classes.join(" ");
+  const className = createClassNameFromProps(
+    buttonClassNameMapping,
+    classNameProps,
+    ["button"]
+  );
 
   return (
-    <button {...props} className={className}>
+    <button className={className} {...props}>
       {props.children}
     </button>
   );

--- a/src/components/column/Column.tsx
+++ b/src/components/column/Column.tsx
@@ -1,4 +1,8 @@
 import { PropsWithChildren } from "react";
+import {
+  ClassNameTransformFn,
+  createClassNameFromProps,
+} from "../../utilities";
 
 export const columnSizes = [
   "one-quarter",
@@ -38,6 +42,17 @@ export type ColumnProps = PropsWithChildren<{
   fullHd?: ColumnSize;
 }>;
 
+const columnClassNameMap = new Map<keyof ColumnProps, ClassNameTransformFn>([
+  ["size", (size: string) => `is-${size}`],
+  ["offset", (offset: string) => `is-offset-${offset}`],
+  ["narrow", () => "is-narrow"],
+  ["mobile", (mobile: string) => `is-${mobile}-mobile`],
+  ["tablet", (tablet: string) => `is-${tablet}-tablet`],
+  ["desktop", (desktop: string) => `is-${desktop}-desktop`],
+  ["widescreen", (widescreen: string) => `is-${widescreen}-widescreen`],
+  ["fullHd", (fullHd: string) => `is-${fullHd}-fullhd`],
+]);
+
 export const Column = ({
   size,
   offset,
@@ -49,34 +64,21 @@ export const Column = ({
   fullHd,
   children,
 }: ColumnProps): JSX.Element => {
-  const classes = ["column"];
-
-  if (size) {
-    classes.push(`is-${size}`);
-  }
-  if (offset) {
-    classes.push(`is-offset-${offset}`);
-  }
-  if (narrow) {
-    classes.push("is-narrow");
-  }
-  if (mobile) {
-    classes.push(`is-${mobile}-mobile`);
-  }
-  if (tablet) {
-    classes.push(`is-${tablet}-tablet`);
-  }
-  if (desktop) {
-    classes.push(`is-${desktop}-desktop`);
-  }
-  if (widescreen) {
-    classes.push(`is-${widescreen}-widescreen`);
-  }
-  if (fullHd) {
-    classes.push(`is-${fullHd}-fullhd`);
-  }
-
-  const className = classes.join(" ");
+  const classNameProps: Partial<ColumnProps> = {
+    size,
+    offset,
+    narrow,
+    mobile,
+    tablet,
+    desktop,
+    widescreen,
+    fullHd,
+  };
+  const className = createClassNameFromProps(
+    columnClassNameMap,
+    classNameProps,
+    ["column"]
+  );
 
   return <div className={className}>{children}</div>;
 };

--- a/src/components/column/Column.tsx
+++ b/src/components/column/Column.tsx
@@ -54,29 +54,12 @@ const columnClassNameMap = new Map<keyof ColumnProps, ClassNameTransformFn>([
 ]);
 
 export const Column = ({
-  size,
-  offset,
-  narrow,
-  mobile,
-  tablet,
-  desktop,
-  widescreen,
-  fullHd,
   children,
+  ...classNameProps
 }: ColumnProps): JSX.Element => {
-  const classNameProps: Partial<ColumnProps> = {
-    size,
-    offset,
-    narrow,
-    mobile,
-    tablet,
-    desktop,
-    widescreen,
-    fullHd,
-  };
   const className = createClassNameFromProps(
     columnClassNameMap,
-    classNameProps,
+    classNameProps as Partial<ColumnProps>,
     ["column"]
   );
 

--- a/src/components/column/Column.tsx
+++ b/src/components/column/Column.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren } from "react";
 import {
-  ClassNameTransformFn,
+  ClassNameTransformMap,
   createClassNameFromProps,
 } from "../../utilities";
 
@@ -42,7 +42,7 @@ export type ColumnProps = PropsWithChildren<{
   fullHd?: ColumnSize;
 }>;
 
-const columnClassNameMap = new Map<keyof ColumnProps, ClassNameTransformFn>([
+const columnClassNameMap: ClassNameTransformMap<ColumnProps> = new Map([
   ["size", (size: string) => `is-${size}`],
   ["offset", (offset: string) => `is-offset-${offset}`],
   ["narrow", () => "is-narrow"],

--- a/src/components/columns/Columns.tsx
+++ b/src/components/columns/Columns.tsx
@@ -21,25 +21,12 @@ const columnsClassNameMap = new Map<keyof ColumnsProps, ClassNameTransformFn>([
 ]);
 
 export const Columns = ({
-  mobile,
-  gapless,
   children,
-  verticallyCentered,
-  multiLine,
-  centered,
+  ...classNameProps
 }: ColumnsProps): JSX.Element => {
-  const classNameProps: Partial<ColumnsProps> = {
-    mobile,
-    gapless,
-    children,
-    verticallyCentered,
-    multiLine,
-    centered,
-  };
-
   const className = createClassNameFromProps(
     columnsClassNameMap,
-    classNameProps,
+    classNameProps as Partial<ColumnsProps>,
     ["columns"]
   );
 

--- a/src/components/columns/Columns.tsx
+++ b/src/components/columns/Columns.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren } from "react";
 import {
-  ClassNameTransformFn,
+  ClassNameTransformMap,
   createClassNameFromProps,
 } from "../../utilities";
 
@@ -12,7 +12,7 @@ export type ColumnsProps = PropsWithChildren<{
   centered?: boolean;
 }>;
 
-const columnsClassNameMap = new Map<keyof ColumnsProps, ClassNameTransformFn>([
+const columnsClassNameMap: ClassNameTransformMap<ColumnsProps> = new Map([
   ["mobile", () => "is-mobile"],
   ["gapless", () => "is-gapless"],
   ["verticallyCentered", () => "is-vcentered"],

--- a/src/components/columns/Columns.tsx
+++ b/src/components/columns/Columns.tsx
@@ -1,4 +1,8 @@
 import { PropsWithChildren } from "react";
+import {
+  ClassNameTransformFn,
+  createClassNameFromProps,
+} from "../../utilities";
 
 export type ColumnsProps = PropsWithChildren<{
   mobile?: boolean;
@@ -8,6 +12,14 @@ export type ColumnsProps = PropsWithChildren<{
   centered?: boolean;
 }>;
 
+const columnsClassNameMap = new Map<keyof ColumnsProps, ClassNameTransformFn>([
+  ["mobile", () => "is-mobile"],
+  ["gapless", () => "is-gapless"],
+  ["verticallyCentered", () => "is-vcentered"],
+  ["multiLine", () => "is-multiline"],
+  ["centered", () => "is-centered"],
+]);
+
 export const Columns = ({
   mobile,
   gapless,
@@ -16,25 +28,20 @@ export const Columns = ({
   multiLine,
   centered,
 }: ColumnsProps): JSX.Element => {
-  const classes = ["columns"];
+  const classNameProps: Partial<ColumnsProps> = {
+    mobile,
+    gapless,
+    children,
+    verticallyCentered,
+    multiLine,
+    centered,
+  };
 
-  if (mobile) {
-    classes.push("is-mobile");
-  }
-  if (gapless) {
-    classes.push("is-gapless");
-  }
-  if (verticallyCentered) {
-    classes.push("is-vcentered");
-  }
-  if (multiLine) {
-    classes.push("is-multiline");
-  }
-  if (centered) {
-    classes.push("is-centered");
-  }
-
-  const className = classes.join(" ");
+  const className = createClassNameFromProps(
+    columnsClassNameMap,
+    classNameProps,
+    ["columns"]
+  );
 
   return <div className={className}>{children}</div>;
 };

--- a/src/components/container/Container.tsx
+++ b/src/components/container/Container.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren } from "react";
 import {
-  ClassNameTransformFn,
+  ClassNameTransformMap,
   createClassNameFromProps,
 } from "../../utilities";
 
@@ -8,10 +8,8 @@ export type ContainerProps = PropsWithChildren<{
   fluid?: boolean;
 }>;
 
-const containerClassNameMapping = new Map<
-  keyof ContainerProps,
-  ClassNameTransformFn
->([["fluid", () => "is-fluid"]]);
+const containerClassNameMapping: ClassNameTransformMap<ContainerProps> =
+  new Map([["fluid", () => "is-fluid"]]);
 
 export const Container = ({
   children,

--- a/src/components/container/Container.tsx
+++ b/src/components/container/Container.tsx
@@ -1,17 +1,27 @@
 import { PropsWithChildren } from "react";
+import {
+  ClassNameTransformFn,
+  createClassNameFromProps,
+} from "../../utilities";
 
 export type ContainerProps = PropsWithChildren<{
   fluid?: boolean;
 }>;
 
-export const Container = ({ fluid, children }: ContainerProps): JSX.Element => {
-  const classes = ["container"];
+const containerClassNameMapping = new Map<
+  keyof ContainerProps,
+  ClassNameTransformFn
+>([["fluid", () => "is-fluid"]]);
 
-  if (fluid) {
-    classes.push("is-fluid");
-  }
-
-  const className = classes.join(" ");
+export const Container = ({
+  children,
+  ...classNameProps
+}: ContainerProps): JSX.Element => {
+  const className = createClassNameFromProps(
+    containerClassNameMapping,
+    classNameProps as Partial<ContainerProps>,
+    ["container"]
+  );
 
   return <div className={className}>{children}</div>;
 };

--- a/src/components/icon/Icon.tsx
+++ b/src/components/icon/Icon.tsx
@@ -1,4 +1,8 @@
 import { Color, Size } from "../../types";
+import {
+  ClassNameTransformFn,
+  createClassNameFromProps,
+} from "../../utilities";
 
 export const iconFontSizes = ["xs", "sm", "lg", "2x"] as const;
 export type IconFontSize = typeof iconFontSizes[number];
@@ -12,6 +16,16 @@ export type IconProps = {
   fontSize?: IconFontSize;
 };
 
+const fontClassNameMapping = new Map<keyof IconProps, ClassNameTransformFn>([
+  ["color", (color: string) => `has-text-${color}`],
+  ["bordered", () => "fa-border"],
+  ["fontSize", (fontSize: string) => `fa-${fontSize}`],
+]);
+
+const iconClassNameMapping = new Map<keyof IconProps, ClassNameTransformFn>([
+  ["containerSize", (containerSize: string) => `is-${containerSize}`],
+]);
+
 export const Icon = ({
   name,
   color,
@@ -20,23 +34,17 @@ export const Icon = ({
   containerSize,
   fontSize,
 }: IconProps): JSX.Element => {
-  const fontClasses = [`fas fa-${name.toLowerCase()}`];
-  if (color) {
-    fontClasses.push(`has-text-${color}`);
-  }
-  if (bordered) {
-    fontClasses.push("fa-border");
-  }
-  if (fontSize) {
-    fontClasses.push(`fa-${fontSize}`);
-  }
-  const fontClassName = fontClasses.join(" ");
+  const fontClassName = createClassNameFromProps(
+    fontClassNameMapping,
+    { color, bordered, fontSize } as Partial<IconProps>,
+    [`fas fa-${name.toLowerCase()}`]
+  );
 
-  const iconClasses = ["icon"];
-  if (containerSize) {
-    iconClasses.push(`is-${containerSize}`);
-  }
-  const iconClassName = iconClasses.join(" ");
+  const iconClassName = createClassNameFromProps(
+    iconClassNameMapping,
+    { containerSize } as Partial<IconProps>,
+    ["icon"]
+  );
 
   return (
     <span className={iconClassName}>

--- a/src/components/icon/Icon.tsx
+++ b/src/components/icon/Icon.tsx
@@ -1,6 +1,6 @@
 import { Color, Size } from "../../types";
 import {
-  ClassNameTransformFn,
+  ClassNameTransformMap,
   createClassNameFromProps,
 } from "../../utilities";
 
@@ -16,13 +16,13 @@ export type IconProps = {
   fontSize?: IconFontSize;
 };
 
-const fontClassNameMapping = new Map<keyof IconProps, ClassNameTransformFn>([
+const fontClassNameMapping: ClassNameTransformMap<IconProps> = new Map([
   ["color", (color: string) => `has-text-${color}`],
   ["bordered", () => "fa-border"],
   ["fontSize", (fontSize: string) => `fa-${fontSize}`],
 ]);
 
-const iconClassNameMapping = new Map<keyof IconProps, ClassNameTransformFn>([
+const iconClassNameMapping: ClassNameTransformMap<IconProps> = new Map([
   ["containerSize", (containerSize: string) => `is-${containerSize}`],
 ]);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./components";
 export * from "./types";
+export * from "./utilities";

--- a/src/utilities/create-class-name/create-class-name.test.ts
+++ b/src/utilities/create-class-name/create-class-name.test.ts
@@ -1,5 +1,9 @@
 import { createClassName } from "./create-class-name";
 
+it("returns an empty string if nothing is provided", () => {
+  expect(createClassName()).toEqual("");
+});
+
 it("returns given default class names", () => {
   const defaultClasses = ["column", "is-mobile"];
   const className = createClassName(defaultClasses);

--- a/src/utilities/create-class-name/create-class-name.test.ts
+++ b/src/utilities/create-class-name/create-class-name.test.ts
@@ -55,4 +55,25 @@ describe("createClassNameFromProps", () => {
       expect(className).toContain(expectedClass);
     });
   });
+
+  it("returns without multiple class names that are false based on given properties", () => {
+    const expectedProperties = ["desktop", "fluid"];
+    const expectedClasses = ["is-desktop", "is-fluid-container"];
+    const classMap = new Map(
+      expectedProperties.map((property, index) => [
+        property,
+        expectedClasses[index],
+      ])
+    );
+    const properties = {
+      [expectedProperties[0]]: false,
+      [expectedProperties[1]]: false,
+    };
+    const className = createClassNameFromProps(classMap, properties, [
+      "default-class",
+    ]);
+    expectedClasses.forEach((expectedClass) => {
+      expect(className).not.toContain(expectedClass);
+    });
+  });
 });

--- a/src/utilities/create-class-name/create-class-name.test.ts
+++ b/src/utilities/create-class-name/create-class-name.test.ts
@@ -23,4 +23,17 @@ describe("createClassNameFromProps", () => {
     const className = createClassNameFromProps(classMap, properties);
     expect(className).toContain(expectedClass);
   });
+
+  it("does not returns with a class name that was false based on given properties", () => {
+    const expectedProperty = "mobile";
+    const expectedClass = "is-mobile";
+    const classMap = new Map([[expectedProperty, expectedClass]]);
+    const properties = {
+      [expectedProperty]: false,
+    };
+    const className = createClassNameFromProps(classMap, properties, [
+      "default-class",
+    ]);
+    expect(className).not.toContain(expectedClass);
+  });
 });

--- a/src/utilities/create-class-name/create-class-name.test.ts
+++ b/src/utilities/create-class-name/create-class-name.test.ts
@@ -13,7 +13,7 @@ describe("createClassNameFromProps", () => {
     });
   });
 
-  it("returns class names that were true based on given properties", () => {
+  it("returns with a class name that was true based on given properties", () => {
     const expectedProperty = "mobile";
     const expectedClass = "is-mobile";
     const classMap = new Map([[expectedProperty, expectedClass]]);

--- a/src/utilities/create-class-name/create-class-name.test.ts
+++ b/src/utilities/create-class-name/create-class-name.test.ts
@@ -12,4 +12,15 @@ describe("createClassNameFromProps", () => {
       expect(className).toContain(defaultClass);
     });
   });
+
+  it("returns class names that were true based on given properties", () => {
+    const expectedProperty = "mobile";
+    const expectedClass = "is-mobile";
+    const classMap = new Map([[expectedProperty, expectedClass]]);
+    const properties = {
+      [expectedProperty]: true,
+    };
+    const className = createClassNameFromProps(classMap, properties);
+    expect(className).toContain(expectedClass);
+  });
 });

--- a/src/utilities/create-class-name/create-class-name.test.ts
+++ b/src/utilities/create-class-name/create-class-name.test.ts
@@ -36,4 +36,23 @@ describe("createClassNameFromProps", () => {
     ]);
     expect(className).not.toContain(expectedClass);
   });
+
+  it("returns with multiple class names that are true based on given properties", () => {
+    const expectedProperties = ["desktop", "fluid"];
+    const expectedClasses = ["is-desktop", "is-fluid-container"];
+    const classMap = new Map(
+      expectedProperties.map((property, index) => [
+        property,
+        expectedClasses[index],
+      ])
+    );
+    const properties = {
+      [expectedProperties[0]]: true,
+      [expectedProperties[1]]: true,
+    };
+    const className = createClassNameFromProps(classMap, properties);
+    expectedClasses.forEach((expectedClass) => {
+      expect(className).toContain(expectedClass);
+    });
+  });
 });

--- a/src/utilities/create-class-name/create-class-name.test.ts
+++ b/src/utilities/create-class-name/create-class-name.test.ts
@@ -76,4 +76,28 @@ describe("createClassNameFromProps", () => {
       expect(className).not.toContain(expectedClass);
     });
   });
+
+  it("returns with multiple class names that are mixed based on given properties", () => {
+    const expectedProperties = ["desktop", "fluid"];
+    const expectedClasses = ["is-desktop", "is-fluid-container"];
+    const classMap = new Map(
+      expectedProperties.map((property, index) => [
+        property,
+        expectedClasses[index],
+      ])
+    );
+    const propertyThatWillMap = expectedProperties[0];
+    const propertyThatWillNotMap = expectedProperties[1];
+    const classThatWillMap = expectedClasses[0];
+    const classThatWillNotMap = expectedClasses[1];
+    const properties = {
+      [propertyThatWillMap]: true,
+      [propertyThatWillNotMap]: false,
+    };
+    const className = createClassNameFromProps(classMap, properties, [
+      "default-class",
+    ]);
+    expect(className).toContain(classThatWillMap);
+    expect(className).not.toContain(classThatWillNotMap);
+  });
 });

--- a/src/utilities/create-class-name/create-class-name.test.ts
+++ b/src/utilities/create-class-name/create-class-name.test.ts
@@ -1,13 +1,23 @@
 import { createClassNameFromProps } from "./create-class-name";
 
+type Props = {
+  mobile?: boolean;
+  desktop?: boolean;
+  fluid?: boolean;
+};
+
 describe("createClassNameFromProps", () => {
   it("returns an empty string if nothing is provided", () => {
-    expect(createClassNameFromProps(new Map([]), {})).toEqual("");
+    expect(createClassNameFromProps<Props>(new Map([]), {})).toEqual("");
   });
 
   it("returns given default class names", () => {
     const defaultClasses = ["column", "is-mobile"];
-    const className = createClassNameFromProps(new Map([]), {}, defaultClasses);
+    const className = createClassNameFromProps<Props>(
+      new Map([]),
+      {},
+      defaultClasses
+    );
     defaultClasses.forEach((defaultClass) => {
       expect(className).toContain(defaultClass);
     });
@@ -16,32 +26,36 @@ describe("createClassNameFromProps", () => {
   it("returns with a class name that was true based on given properties", () => {
     const expectedProperty = "mobile";
     const expectedClass = "is-mobile";
-    const classMap = new Map([[expectedProperty, expectedClass]]);
+    const classMap = new Map<keyof Props, string>([
+      [expectedProperty, expectedClass],
+    ]);
     const properties = {
       [expectedProperty]: true,
     };
-    const className = createClassNameFromProps(classMap, properties);
+    const className = createClassNameFromProps<Props>(classMap, properties);
     expect(className).toContain(expectedClass);
   });
 
   it("does not return with a class name that was false based on given properties", () => {
     const expectedProperty = "mobile";
     const expectedClass = "is-mobile";
-    const classMap = new Map([[expectedProperty, expectedClass]]);
+    const classMap = new Map<keyof Props, string>([
+      [expectedProperty, expectedClass],
+    ]);
     const properties = {
       [expectedProperty]: false,
     };
-    const className = createClassNameFromProps(classMap, properties, [
+    const className = createClassNameFromProps<Props>(classMap, properties, [
       "default-class",
     ]);
     expect(className).not.toContain(expectedClass);
   });
 
   it("returns with multiple class names that are true based on given properties", () => {
-    const expectedProperties = ["desktop", "fluid"];
-    const expectedClasses = ["is-desktop", "is-fluid-container"];
-    const classMap = new Map(
-      expectedProperties.map((property, index) => [
+    const expectedProperties: (keyof Props)[] = ["desktop", "fluid"];
+    const expectedClasses: string[] = ["is-desktop", "is-fluid-container"];
+    const classMap = new Map<keyof Props, string>(
+      expectedProperties.map((property: keyof Props, index: number) => [
         property,
         expectedClasses[index],
       ])
@@ -50,7 +64,7 @@ describe("createClassNameFromProps", () => {
       [expectedProperties[0]]: true,
       [expectedProperties[1]]: true,
     };
-    const className = createClassNameFromProps(classMap, properties);
+    const className = createClassNameFromProps<Props>(classMap, properties);
     expectedClasses.forEach((expectedClass) => {
       expect(className).toContain(expectedClass);
     });

--- a/src/utilities/create-class-name/create-class-name.test.ts
+++ b/src/utilities/create-class-name/create-class-name.test.ts
@@ -26,8 +26,8 @@ describe("createClassNameFromProps", () => {
   it("returns with a class name that was true based on given properties", () => {
     const expectedProperty = "mobile";
     const expectedClass = "is-mobile";
-    const classMap = new Map<keyof Props, string>([
-      [expectedProperty, expectedClass],
+    const classMap = new Map<keyof Props, () => string>([
+      [expectedProperty, () => expectedClass],
     ]);
     const properties = {
       [expectedProperty]: true,
@@ -39,8 +39,8 @@ describe("createClassNameFromProps", () => {
   it("does not return with a class name that was false based on given properties", () => {
     const expectedProperty = "mobile";
     const expectedClass = "is-mobile";
-    const classMap = new Map<keyof Props, string>([
-      [expectedProperty, expectedClass],
+    const classMap = new Map<keyof Props, () => string>([
+      [expectedProperty, () => expectedClass],
     ]);
     const properties = {
       [expectedProperty]: false,
@@ -54,10 +54,10 @@ describe("createClassNameFromProps", () => {
   it("returns with multiple class names that are true based on given properties", () => {
     const expectedProperties: (keyof Props)[] = ["desktop", "fluid"];
     const expectedClasses: string[] = ["is-desktop", "is-fluid-container"];
-    const classMap = new Map<keyof Props, string>(
+    const classMap = new Map<keyof Props, () => string>(
       expectedProperties.map((property: keyof Props, index: number) => [
         property,
-        expectedClasses[index],
+        () => expectedClasses[index],
       ])
     );
     const properties = {
@@ -71,12 +71,12 @@ describe("createClassNameFromProps", () => {
   });
 
   it("returns without multiple class names that are false based on given properties", () => {
-    const expectedProperties = ["desktop", "fluid"];
-    const expectedClasses = ["is-desktop", "is-fluid-container"];
-    const classMap = new Map(
-      expectedProperties.map((property, index) => [
+    const expectedProperties: (keyof Props)[] = ["desktop", "fluid"];
+    const expectedClasses: string[] = ["is-desktop", "is-fluid-container"];
+    const classMap = new Map<keyof Props, () => string>(
+      expectedProperties.map((property: keyof Props, index: number) => [
         property,
-        expectedClasses[index],
+        () => expectedClasses[index],
       ])
     );
     const properties = {
@@ -92,12 +92,12 @@ describe("createClassNameFromProps", () => {
   });
 
   it("returns with multiple class names that are mixed based on given properties", () => {
-    const expectedProperties = ["desktop", "fluid"];
-    const expectedClasses = ["is-desktop", "is-fluid-container"];
-    const classMap = new Map(
-      expectedProperties.map((property, index) => [
+    const expectedProperties: (keyof Props)[] = ["desktop", "fluid"];
+    const expectedClasses: string[] = ["is-desktop", "is-fluid-container"];
+    const classMap = new Map<keyof Props, () => string>(
+      expectedProperties.map((property: keyof Props, index: number) => [
         property,
-        expectedClasses[index],
+        () => expectedClasses[index],
       ])
     );
     const propertyThatWillMap = expectedProperties[0];

--- a/src/utilities/create-class-name/create-class-name.test.ts
+++ b/src/utilities/create-class-name/create-class-name.test.ts
@@ -1,13 +1,15 @@
-import { createClassName } from "./create-class-name";
+import { createClassNameFromProps } from "./create-class-name";
 
-it("returns an empty string if nothing is provided", () => {
-  expect(createClassName()).toEqual("");
-});
+describe("createClassNameFromProps", () => {
+  it("returns an empty string if nothing is provided", () => {
+    expect(createClassNameFromProps(new Map([]), {})).toEqual("");
+  });
 
-it("returns given default class names", () => {
-  const defaultClasses = ["column", "is-mobile"];
-  const className = createClassName(defaultClasses);
-  defaultClasses.forEach((defaultClass) => {
-    expect(className).toContain(defaultClass);
+  it("returns given default class names", () => {
+    const defaultClasses = ["column", "is-mobile"];
+    const className = createClassNameFromProps(new Map([]), {}, defaultClasses);
+    defaultClasses.forEach((defaultClass) => {
+      expect(className).toContain(defaultClass);
+    });
   });
 });

--- a/src/utilities/create-class-name/create-class-name.test.ts
+++ b/src/utilities/create-class-name/create-class-name.test.ts
@@ -24,7 +24,7 @@ describe("createClassNameFromProps", () => {
     expect(className).toContain(expectedClass);
   });
 
-  it("does not returns with a class name that was false based on given properties", () => {
+  it("does not return with a class name that was false based on given properties", () => {
     const expectedProperty = "mobile";
     const expectedClass = "is-mobile";
     const classMap = new Map([[expectedProperty, expectedClass]]);

--- a/src/utilities/create-class-name/create-class-name.test.ts
+++ b/src/utilities/create-class-name/create-class-name.test.ts
@@ -1,0 +1,9 @@
+import { createClassName } from "./create-class-name";
+
+it("returns given default class names", () => {
+  const defaultClasses = ["column", "is-mobile"];
+  const className = createClassName(defaultClasses);
+  defaultClasses.forEach((defaultClass) => {
+    expect(className).toContain(defaultClass);
+  });
+});

--- a/src/utilities/create-class-name/create-class-name.test.ts
+++ b/src/utilities/create-class-name/create-class-name.test.ts
@@ -1,9 +1,13 @@
-import { createClassNameFromProps } from "./create-class-name";
+import {
+  ClassNameTransformFn,
+  createClassNameFromProps,
+} from "./create-class-name";
 
 type Props = {
   mobile?: boolean;
   desktop?: boolean;
   fluid?: boolean;
+  color?: string;
 };
 
 describe("createClassNameFromProps", () => {
@@ -34,6 +38,19 @@ describe("createClassNameFromProps", () => {
     };
     const className = createClassNameFromProps<Props>(classMap, properties);
     expect(className).toContain(expectedClass);
+  });
+
+  it("returns with a transformed class name that was true based on given properties", () => {
+    const expectedProperty = "color";
+    const classMap = new Map<keyof Props, ClassNameTransformFn>([
+      [expectedProperty, (color: string) => `is-${color}`],
+    ]);
+    const expectedValue = "blue";
+    const properties = {
+      [expectedProperty]: expectedValue,
+    };
+    const className = createClassNameFromProps<Props>(classMap, properties);
+    expect(className).toContain(`is-${expectedValue}`);
   });
 
   it("does not return with a class name that was false based on given properties", () => {

--- a/src/utilities/create-class-name/create-class-name.ts
+++ b/src/utilities/create-class-name/create-class-name.ts
@@ -1,5 +1,5 @@
 export const createClassNameFromProps = <T extends Record<string, unknown>>(
-  classMap: Map<keyof T, string>,
+  classMap: Map<keyof T, (value?: string) => string>,
   props: Partial<T>,
   defaultClasses: string[] = []
 ): string => {
@@ -7,8 +7,11 @@ export const createClassNameFromProps = <T extends Record<string, unknown>>(
 
   Object.keys(props).forEach((prop) => {
     const value = props[prop];
-    if (value && classMap.get(prop)) {
-      classes.push(classMap.get(prop) as string);
+    if (value) {
+      const transform = classMap.get(prop);
+      if (transform) {
+        classes.push(transform(value as string));
+      }
     }
   });
 

--- a/src/utilities/create-class-name/create-class-name.ts
+++ b/src/utilities/create-class-name/create-class-name.ts
@@ -1,5 +1,19 @@
 export type ClassNameTransformFn = (() => string) | ((value: string) => string);
 
+/**
+ * Returns a formatted className given information about props. A Map
+ * is provided that allows a consumer to specify transformation behavior
+ * that determines what class names should be generated based upon
+ * the "truthy"ness of a given property value.
+ *
+ * Only properties that are considered truthy will have their transform functions
+ * called. Falsy properties will be ignored.
+ *
+ * @param classMap A mapping of transform functions that is keyed based upon prop keys.
+ * @param props The props, usually these would be 1:1  with the props of an associated React component.
+ * @param defaultClasses Default classes to always include no matter what
+ * @returns A single string that contains all of the classes generated based upon the "truthy"ness of given properties.
+ */
 export const createClassNameFromProps = <T extends Record<string, unknown>>(
   classMap: Map<keyof T, ClassNameTransformFn>,
   props: Partial<T>,

--- a/src/utilities/create-class-name/create-class-name.ts
+++ b/src/utilities/create-class-name/create-class-name.ts
@@ -1,13 +1,13 @@
 export const createClassNameFromProps = (
   classMap: Map<string, string>,
-  properties: Record<string, boolean>,
+  props: Record<string, boolean>,
   defaultClasses: string[] = []
 ): string => {
   const classes = [...defaultClasses];
 
-  Object.keys(properties).forEach((property) => {
-    if (property && classMap.get(property)) {
-      classes.push(classMap.get(property) as string);
+  Object.keys(props).forEach((prop) => {
+    if (prop && classMap.get(prop)) {
+      classes.push(classMap.get(prop) as string);
     }
   });
 

--- a/src/utilities/create-class-name/create-class-name.ts
+++ b/src/utilities/create-class-name/create-class-name.ts
@@ -1,4 +1,5 @@
 export type ClassNameTransformFn = (() => string) | ((value: string) => string);
+export type ClassNameTransformMap<T> = Map<keyof T, ClassNameTransformFn>;
 
 /**
  * Returns a formatted className given information about props. A Map

--- a/src/utilities/create-class-name/create-class-name.ts
+++ b/src/utilities/create-class-name/create-class-name.ts
@@ -1,6 +1,6 @@
-export const createClassNameFromProps = (
-  classMap: Map<string, string>,
-  props: Record<string, boolean>,
+export const createClassNameFromProps = <T extends Record<string, unknown>>(
+  classMap: Map<keyof T, string>,
+  props: Partial<T>,
   defaultClasses: string[] = []
 ): string => {
   const classes = [...defaultClasses];

--- a/src/utilities/create-class-name/create-class-name.ts
+++ b/src/utilities/create-class-name/create-class-name.ts
@@ -22,12 +22,10 @@ export const createClassNameFromProps = <T extends Record<string, unknown>>(
   const classes = [...defaultClasses];
 
   Object.keys(props).forEach((prop) => {
-    const value = props[prop];
-    if (value) {
-      const transform = classMap.get(prop);
-      if (transform) {
-        classes.push(transform(value as string));
-      }
+    const value = props[prop] as string;
+    const transform = classMap.get(prop);
+    if (value && transform) {
+      classes.push(transform(value));
     }
   });
 

--- a/src/utilities/create-class-name/create-class-name.ts
+++ b/src/utilities/create-class-name/create-class-name.ts
@@ -1,4 +1,15 @@
-export const createClassName = (defaultClasses: string[] = []): string => {
+export const createClassNameFromProps = (
+  classMap: Map<string, string>,
+  properties: Record<string, boolean>,
+  defaultClasses: string[] = []
+): string => {
   const classes = [...defaultClasses];
+
+  Object.keys(properties).forEach((property) => {
+    if (property && classMap.get(property)) {
+      classes.push(classMap.get(property) as string);
+    }
+  });
+
   return classes.join(" ");
 };

--- a/src/utilities/create-class-name/create-class-name.ts
+++ b/src/utilities/create-class-name/create-class-name.ts
@@ -1,5 +1,7 @@
+export type ClassNameTransformFn = (() => string) | ((value: string) => string);
+
 export const createClassNameFromProps = <T extends Record<string, unknown>>(
-  classMap: Map<keyof T, (value?: string) => string>,
+  classMap: Map<keyof T, ClassNameTransformFn>,
   props: Partial<T>,
   defaultClasses: string[] = []
 ): string => {

--- a/src/utilities/create-class-name/create-class-name.ts
+++ b/src/utilities/create-class-name/create-class-name.ts
@@ -6,7 +6,8 @@ export const createClassNameFromProps = (
   const classes = [...defaultClasses];
 
   Object.keys(props).forEach((prop) => {
-    if (prop && classMap.get(prop)) {
+    const value = props[prop];
+    if (value && classMap.get(prop)) {
       classes.push(classMap.get(prop) as string);
     }
   });

--- a/src/utilities/create-class-name/create-class-name.ts
+++ b/src/utilities/create-class-name/create-class-name.ts
@@ -1,0 +1,4 @@
+export const createClassName = (defaultClasses: string[] = []): string => {
+  const classes = [...defaultClasses];
+  return classes.join(" ");
+};

--- a/src/utilities/create-class-name/index.ts
+++ b/src/utilities/create-class-name/index.ts
@@ -1,0 +1,1 @@
+export * from "./create-class-name";

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,0 +1,1 @@
+export * from "./create-class-name";


### PR DESCRIPTION
Bulma components and elements use a lot of class names to indicate state. Which is cool -- because BEM styled selectors and semantic / modifier classes are sweeeeet.

But there was a ton of redundancy in my components of chained `if` statements. I have now built a utility function that should hopefully more gracefully handle `className` calculation in the future that solves the current frustrations.