### PR TITLE
fix: Fix Forwarding of Refs to Semantic Form Field -> ValidatedInput -> Input

### DIFF
--- a/src/components/form/input/Input.tsx
+++ b/src/components/form/input/Input.tsx
@@ -1,4 +1,4 @@
-import { InputHTMLAttributes } from "react";
+import { forwardRef, InputHTMLAttributes, Ref } from "react";
 import { Color, Size } from "../../../types";
 import {
   ClassNameTransformMap,
@@ -22,17 +22,16 @@ const classNameMap: ClassNameTransformMap<InputProps> = new Map([
   ["isStatic", () => "is-static"],
 ]);
 
-export const Input = ({
-  color,
-  size,
-  isStatic,
-  rounded,
-  ...props
-}: InputProps): JSX.Element => {
-  const className = createClassNameFromProps(
-    classNameMap,
-    { color, size, isStatic, rounded } as Partial<InputProps>,
-    ["input"]
-  );
-  return <input className={className} {...props} />;
-};
+export const Input = forwardRef(
+  (
+    { color, size, isStatic, rounded, ...props }: InputProps,
+    ref: Ref<HTMLInputElement>
+  ): JSX.Element => {
+    const className = createClassNameFromProps(
+      classNameMap,
+      { color, size, isStatic, rounded } as Partial<InputProps>,
+      ["input"]
+    );
+    return <input className={className} {...props} ref={ref} />;
+  }
+);

--- a/src/components/form/semantic-form-field/SemanticFormField.tsx
+++ b/src/components/form/semantic-form-field/SemanticFormField.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { forwardRef, ReactNode, Ref } from "react";
 import {
   Label,
   FormControl,
@@ -31,35 +31,41 @@ export type SemanticFormFieldProps = {
  * component intentionally favors an inheritance approach vs
  * composition for spinning up standard, similar inputs.
  */
-export const SemanticFormField = ({
-  id,
-  label,
-  help,
-  control,
-  input,
-  icons,
-  error,
-  register,
-}: SemanticFormFieldProps): JSX.Element => {
-  const helpId = help || error ? `${id}-help` : undefined;
-  const valid = !error;
+export const SemanticFormField = forwardRef(
+  (
+    {
+      id,
+      label,
+      help,
+      control,
+      input,
+      icons,
+      error,
+      register,
+    }: SemanticFormFieldProps,
+    ref: Ref<HTMLInputElement>
+  ): JSX.Element => {
+    const helpId = help || error ? `${id}-help` : undefined;
+    const valid = !error;
 
-  return (
-    <FormField>
-      <Label htmlFor={id}>{label}</Label>
-      <FormControl {...control}>
-        {icons}
-        <ValidatedInput
-          {...input}
-          id={id}
-          aria-describedby={helpId}
-          valid={valid}
-          {...register}
-        />
-      </FormControl>
-      <Help id={helpId} error={error}>
-        {help}
-      </Help>
-    </FormField>
-  );
-};
+    return (
+      <FormField>
+        <Label htmlFor={id}>{label}</Label>
+        <FormControl {...control}>
+          {icons}
+          <ValidatedInput
+            {...input}
+            id={id}
+            aria-describedby={helpId}
+            valid={valid}
+            {...register}
+            ref={ref}
+          />
+        </FormControl>
+        <Help id={helpId} error={error}>
+          {help}
+        </Help>
+      </FormField>
+    );
+  }
+);

--- a/src/components/form/validated-input/ValidatedInput.tsx
+++ b/src/components/form/validated-input/ValidatedInput.tsx
@@ -1,3 +1,4 @@
+import { forwardRef, Ref } from "react";
 import { Input, InputProps } from "../input";
 
 export type ValidatedInputProps = InputProps & {
@@ -10,10 +11,12 @@ export type ValidatedInputProps = InputProps & {
  * `valid` prop passed by the consumer, so there is no opinion on how
  * an input is technically validated.
  */
-export const ValidatedInput = ({
-  valid,
-  ...props
-}: ValidatedInputProps): JSX.Element => {
-  const color = valid ? props.color : "danger";
-  return <Input {...props} color={color} aria-invalid={!valid} />;
-};
+export const ValidatedInput = forwardRef(
+  (
+    { valid, ...props }: ValidatedInputProps,
+    ref: Ref<HTMLInputElement>
+  ): JSX.Element => {
+    const color = valid ? props.color : "danger";
+    return <Input {...props} color={color} aria-invalid={!valid} ref={ref} />;
+  }
+);


### PR DESCRIPTION
Allows for a ref to be forwarded to the actual result HTML `<input>` tag. Useful for when libraries like react-hook-form are used to register on an input.