### PR TITLE
Release 2.0.0 version of Kecleon

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
   "directories": {
     "lib": "lib"
   },
-  "flies": [
-    "lib"
-  ],
   "version": "0.0.2",
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.3",


### PR DESCRIPTION
Using a somewhat compound component-like pattern, I am favoring to use composition for the input control in SemanticFormField instead of a prop that gets converted into a component.

To fix the breaking change:

Instead of using the input prop, provide the <Input> element as a child of the SemanticFormField. The SemanticFormField will pass props to this child component for the proper binding and mapping to the label, error, and help message. This is where the compount-like logic is.