### PR TITLE
fix: Bundling of SCSS Module Files

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,12 +24,11 @@
     "url": "https://github.com/Tiernebre/kecleon.git"
   },
   "scripts": {
-    "bundle:css": "copyfiles -u 1 src/styles/**/* lib && copyfiles -u 1 src/**/*.css lib",
-    "bundle:scss": "copyfiles -u 1 src/styles/**/* lib && copyfiles -u 1 src/**/*.scss lib",
+    "bundle:scss": "copyfiles -u 1 src/styles/**/* lib && copyfiles -u 1 src/components/**/*.scss lib",
     "clean": "rimraf ./lib",
     "prebuild": "yarn clean",
     "build": "tsc --p tsconfig.lib.json",
-    "postbuild": "yarn bundle:css && yarn bundle:scss",
+    "postbuild": "yarn bundle:scss",
     "format": "prettier --write .",
     "lint": "prettier --check . && eslint . --max-warnings=0",
     "test": "react-scripts test",


### PR DESCRIPTION
Turns out the existing bundling of CSS files didn't work when used with SCSS. This fixes that so the SCSS files get properly bundled.